### PR TITLE
rewrite RPS and IR calculations without using (deprecated) DataFrame.append

### DIFF
--- a/RPS and IR calculation.py
+++ b/RPS and IR calculation.py
@@ -4,7 +4,7 @@
 
 #For simplicity, in this example it is assumed that the data provided cover a single evaluation period.
 #This period is specified through the min/max date of the asset prices data set.
-#If you wish to compute RPS/IR for multiple periods, you'll have to execute 
+#If you wish to compute RPS/IR for multiple periods, you'll have to execute
 #the script multiple times, each time using a different, appropriate input.
 
 import pandas as pd
@@ -23,39 +23,42 @@ submission = submission_data
 
 #Function for computing RPS
 def RPS_calculation(hist_data, submission, asset_no=100):
-    
+
     if hist_data.shape[0]<=asset_no:
-        return np.nan    
-    
+        return np.nan
+
     asset_id = pd.unique(hist_data.symbol)
-    
+
+    _hist_data = []
     for i in range(len(pd.unique(hist_data.date))):
         if len(hist_data[hist_data.date == pd.unique(hist_data.date)[i]])<len(asset_id):
             for asset in [x for x in asset_id if x not in hist_data[hist_data.date == pd.unique(hist_data.date)[i]].symbol.values]:
                 right_price = hist_data[hist_data.symbol==asset].sort_values(by='date')
                 right_price = right_price[right_price.date <= pd.unique(hist_data.date)[i]]
                 right_price = right_price.price.iloc[-1]
-                hist_data = hist_data.append({'date' : pd.unique(hist_data.date)[i],
+                _hist_data.append({'date' : pd.unique(hist_data.date)[i],
                                                'symbol' : asset,
-                                               'price' : right_price}, ignore_index=True)
+                                               'price' : right_price})
+    hist_data = pd.concat([hist_data, pd.DataFrame(_hist_data)], ignore_index=True)
 
     #Compute percentage returns
-    asset_id = sorted(asset_id) 
+    asset_id = sorted(asset_id)
 
     #Compute percentage returns
-    returns = pd.DataFrame(columns = ["ID", "Return"])
-    
+    returns = []
+
     min_date = min(hist_data.date)
     max_date = max(hist_data.date)
-    
+
     for i in range(0,len(asset_id)):
         temp = hist_data.loc[hist_data.symbol==asset_id[i]]
-        
+
         open_price = float(temp.loc[temp.date==min_date].price)
         close_price = float(temp.loc[temp.date==max_date].price)
-        
-        returns = returns.append({'ID': temp.symbol.iloc[0], 
-                                'Return': (close_price - open_price)/open_price}, ignore_index=True)
+
+        returns.append({'ID': temp.symbol.iloc[0],
+                        'Return': (close_price - open_price)/open_price})
+    returns = pd.DataFrame(returns)
 
     #Define the relevant position of each asset
     ranking = pd.DataFrame(columns=["ID", "Position", "Return"])
@@ -74,7 +77,7 @@ def RPS_calculation(hist_data, submission, asset_no=100):
 
     total_ranks = Series_per_position.Position.values[-1]
     for i in range(0,Series_per_position.shape[0]):
-    
+
         start_p = Series_per_position.Position[i]
         end_p = Series_per_position.Position[i] + Series_per_position.Series[i]
         temp = pd.DataFrame(columns = ["Position","Rank", "Rank1", "Rank2", "Rank3", "Rank4","Rank5"])
@@ -106,7 +109,7 @@ def RPS_calculation(hist_data, submission, asset_no=100):
     ranking = pd.merge(ranking,Series_per_position, on = "Position")
     ranking = ranking[["ID", "Return", "Position", "Rank", "Rank1", "Rank2", "Rank3", "Rank4", "Rank5"]]
     ranking = ranking.sort_values(["Position"])
-    
+
     #Evaluate submission
     rps_sub = []
     #for aid in list((pd.unique(ranking.ID))):
@@ -116,29 +119,30 @@ def RPS_calculation(hist_data, submission, asset_no=100):
         frc = np.cumsum(submission.loc[submission.ID==aid].iloc[:,1:6].values).tolist()
         rps_sub.append(np.mean([(a - b)**2 for a, b in zip(target, frc)]))
     submission["RPS"] = rps_sub
-    
+
     output = {'RPS' : np.mean(rps_sub),
               'details' : submission}
-    
+
     return(output)
-   
+
 #Function for computing IR
 def IR_calculation(hist_data, submission):
-    
+
     asset_id = pd.unique(hist_data.symbol)
-    
+
+    _hist_data = []
     for i in range(len(pd.unique(hist_data.date))):
         if len(hist_data[hist_data.date == pd.unique(hist_data.date)[i]])<len(asset_id):
             for asset in [x for x in asset_id if x not in hist_data[hist_data.date == pd.unique(hist_data.date)[i]].symbol.values]:
                 right_price = hist_data[hist_data.symbol==asset].sort_values(by='date')
                 right_price = right_price[right_price.date <= pd.unique(hist_data.date)[i]]
                 right_price = right_price.price.iloc[-1]
-                hist_data = hist_data.append({'date' : pd.unique(hist_data.date)[i],
+                _hist_data.append({'date' : pd.unique(hist_data.date)[i],
                                                'symbol' : asset,
-                                               'price' : right_price}, ignore_index=True)
+                                               'price' : right_price})
+    hist_data = pd.concat([hist_data, pd.DataFrame(_hist_data)], ignore_index=True)
 
-
-    asset_id = sorted(asset_id) 
+    asset_id = sorted(asset_id)
 
     #Compute percentage returns
     returns = pd.DataFrame(columns = ["ID", "Return"])
@@ -146,27 +150,28 @@ def IR_calculation(hist_data, submission):
     #Investment weights
     weights = submission[["ID","Decision"]]
 
-    RET = pd.DataFrame()
+    RET = []
 
     for i in range(len(asset_id)):
         temp = hist_data.loc[hist_data.symbol==asset_id[i]]
         temp = temp.sort_values(by='date')
         temp.reset_index(inplace=True, drop=True)
-        RET = RET.append(temp.price.pct_change()*weights.loc[weights.ID==asset_id[i]].Decision.values[0])
+        RET.append(temp.price.pct_change()*weights.loc[weights.ID==asset_id[i]].Decision.values[0])
+    RET = pd.DataFrame(RET)
 
     ret = np.log(1+RET.sum()[1:])
     sum_ret = sum(ret)
     sdp = stdev(ret)
-    
+
     output = {'IR' : sum_ret/sdp,
               'details' : list(ret)}
-    
-    
+
+
     return output
-    
+
 #Run evaluation
 RPS_calculation(hist_data = asset_data , submission = submission_data)['RPS']
 
 IR_calculation(hist_data, submission)['IR']
 
-    
+


### PR DESCRIPTION
`DataFrame.append` is deprecated in pandas, so I'm suggesting to rewrite the calculation without using it